### PR TITLE
Bring back removed/disabled but still functional entities.

### DIFF
--- a/lua/caf/stools/ls3_energysystems.lua
+++ b/lua/caf/stools/ls3_energysystems.lua
@@ -240,7 +240,7 @@ TOOL.Devices = {
             },
         },
     },
-    --[[generator_liquid_nitrogen = {
+    generator_liquid_nitrogen = {
          Name	= "Liquid Nitrogen Generator",
          type	= "generator_liquid_nitrogen",
          class	= "generator_liquid_nitrogen",
@@ -248,12 +248,12 @@ TOOL.Devices = {
          devices = {
              default_nitrogen_rec = {
                  Name	= "CS Liquid Nitrogen Generator (Default)",
-                 model	= "models/chipstiks_ls3_models/oxygencompressor/oxygencompressor.mdl",
+                 model	= "models/chipstiks_ls3_models/nitrogenliquifier/nitrogenliquifier.mdl",
                  skin	= 0,
                  legacy	= false, --these two vars must be defined per ent as the old tanks (defined in external file) require different values
              },
          },
-     },]]
+     },
     generator_gas_co2 = {
         Name = "Carbon Dioxide Compressor",
         type = "generator_gas_co2",

--- a/lua/caf/stools/ls3_energysystems/extra_ln_gens.lua
+++ b/lua/caf/stools/ls3_energysystems/extra_ln_gens.lua
@@ -1,11 +1,11 @@
---[[DEVICEGROUP.type			= "generator_liquid_nitrogen"]]
+DEVICEGROUP.type = "generator_liquid_nitrogen"
 
 --[[
 	You can also use skin = number here to define a skin to make the Module spawn with
 	You can also use material = "path/to/material" to set a material to make it spawn with
 ]]
 
---[[DEVICEGROUP.devices = {
+DEVICEGROUP.devices = {
 	add_one = {
 		Name		= "CE Small Liquid Nitrogen Compressor",
 		model		= "models/ce_ls3additional/compressor/compressor.mdl",
@@ -21,10 +21,5 @@
 		model		= "models/ce_ls3additional/compressor/compressor_huge.mdl",
 		skin 		= 4
 	},
-	add_4 = {
-		Name		= "CS Nitrogen Liquifier",
-		model		= "models/chipstiks_ls3_models/nitrogenliquifier/nitrogenliquifier.mdl",
-		skin 		= 0
-	},
-}]]
+}
 

--- a/lua/caf/stools/ls3_environmental_control.lua
+++ b/lua/caf/stools/ls3_environmental_control.lua
@@ -175,6 +175,12 @@ TOOL.Devices = {
                 skin = 0,
                 legacy = false,
             },
+			small = {
+				Name = "Small Climate Regulator",
+				model = "models/smallbridge/life support/sbclimatereg.mdl",
+				skin = 0,
+				legacy = false;
+			},
         },
     },
     other_probe = {

--- a/lua/caf/stools/sb_terraformer.lua
+++ b/lua/caf/stools/sb_terraformer.lua
@@ -63,7 +63,7 @@ TOOL.Devices = {
         devices = {
             default = {
                 Name = "Basic Terraformer",
-                model = "models/ce_ls3additional/plants/plantfull.mdl",
+                model = "models/chipstiks_ls3_models/terraformer/terraformer.mdl",
             },
         },
     },


### PR DESCRIPTION
This re-adds the smaller climate regulator that can be skinned to match SBEP hull designs, restores the terraformer to its original model, and adds back liquid nitrogen. 
Looking through the code there are still the functions for the hot liquid nitrogen entities, however no models, textures, or actual code for the entities appear to still exist. 
By re-adding liquid nitrogen we can also potentially re-add the nitrogen recycler, and if hot liquid nitrogen is ever re-added it would allow for the liquid nitrogen recycler to be re-implemented as well. 
