### PR TITLE
Add the entity the FGD needs to work

### DIFF
--- a/lua/caf/stools/ls3_energysystems.lua
+++ b/lua/caf/stools/ls3_energysystems.lua
@@ -443,6 +443,12 @@ TOOL.Devices = {
                 skin = 0,
                 legacy = false,
             },
+            extra_small = {
+            	Name = "Extra Small"
+            	model = "models/ls_models/cloudstrifexiii/windmill/windmill_extra_small.mdl",
+            	skin = 0,
+            	legacy = false,
+    	    },
         },
     },
     generator_h_ramscoop = {

--- a/lua/entities/sb_environment/extensions/sv_brush_env_base_funcs.lua
+++ b/lua/entities/sb_environment/extensions/sv_brush_env_base_funcs.lua
@@ -1,0 +1,558 @@
+local SB_AIR_EMPTY = -1
+local SB_AIR_O2 = 0
+local SB_AIR_CO2 = 1
+local SB_AIR_N = 2
+local SB_AIR_H = 3
+
+function SB_Brush_Environment_Load_Base_Func_Extensions1(ENT) -- HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ!
+
+	function ENT:GetUnstable()
+		return self.sbenvironment.unstable
+	end
+
+	function ENT:GetTemperature()
+		return self.sbenvironment.temperature or 0
+	end
+
+	function ENT:Unstable()
+		if self.Entity.sbenvironment.unstable then
+			--Add some unstable planet shake thingy code here
+		end
+	end
+
+	function ENT:IsPlanet()
+		return false
+	end
+
+	function ENT:Think()
+		self:Unstable()
+		self.Entity:NextThink(CurTime() + 1)
+		return true
+	end
+
+	function ENT:SendBloom()
+		--We'll figure this shit out later
+	end
+
+	function ENT:SendColor()
+		--We'll figure this shit out later
+	end
+
+	function ENT:GetEnvironmentID()
+		return self.sbenvironment.id or 0
+	end
+
+	function ENT:PrintVars()
+		Msg("Print Environment Data\n")
+		PrintTable(self.sbenvironment)
+		Msg("End Print Environment Data\n")
+	end
+
+	function ENT:GetEnvClass()
+		return "SB ENVIRONMENT"
+	end
+
+	function ENT:GetSize()
+		return 9000 + 1
+	end
+
+	function ENT:GetPriority()
+		return 9000 + (self.PriorityOverride or 1)
+	end
+
+	function ENT:GetO2Percentage()
+		if not self.sbenvironment.air.max then
+			self:CalcAirMax()
+		elseif self.sbenvironment.air.max == 0 then
+			return
+		end
+		
+		return ((self.sbenvironment.air.o2  / self.sbenvironment.air.max) * 100)
+	end
+
+	function ENT:GetCO2Percentage()
+		if not self.sbenvironment.air.max then
+			self:CalcAirMax()
+		elseif self.sbenvironment.air.max == 0 then
+			return
+		end
+		
+		return ((self.sbenvironment.air.co2  / self.sbenvironment.air.max) * 100)
+	end
+	
+	function ENT:GetNPercentage()
+		if not self.sbenvironment.air.max then
+			self:CalcAirMax()
+		elseif self.sbenvironment.air.max == 0 then
+			return
+		end
+		
+		return ((self.sbenvironment.air.n  / self.sbenvironment.air.max) * 100)
+	end
+
+	function ENT:GetHPercentage()
+		if not self.sbenvironment.air.max then
+			self:CalcAirMax()
+		elseif self.sbenvironment.air.max == 0 then
+			return
+		end
+		
+		return ((self.sbenvironment.air.h / self.sbenvironment.air.max) * 100)
+	end
+	
+	function ENT:GetOtherGasPercentage()
+		if not self.sbenvironment.air.max then
+			self:CalcAirMax()
+		elseif self.sbenvironment.air.max == 0 then
+			return
+		end
+		
+		return ((self.sbenvironment.air.other / self.sbenvironment.air.max) * 100)
+	end
+	
+	function ENT:CalcAirMax()
+		self.sbenvironment.air.max = self.sbenvironment.air.other +
+									 self.sbenvironment.air.h +
+									 self.sbenvironment.air.n +
+									 self.sbenvironment.air.co2 +
+									 self.sbenvironment.air.o2 
+	end
+
+	function ENT:SetSize(size)
+		return Error("Cant set the size of a brush env!\n")
+	end
+
+	function ENT:ChangeAtmosphere(newatmosphere)
+		if not newatmosphere or type(newatmosphere) != "number" then return Error("Invalid parameter\n") end
+		if newatmosphere < 0 then
+			newatmosphere = 0
+		elseif newatmosphere > 1 then
+			newatmosphere = 1
+		end
+		//Update the pressure since it's based on atmosphere and gravity
+		if self.sbenvironment.atmosphere != 0 then
+			self.sbenvironment.pressure = self.sbenvironment.pressure * (newatmosphere/self.sbenvironment.atmosphere)
+		else
+			self.sbenvironment.pressure = self.sbenvironment.pressure * newatmosphere
+		end
+		//Update air values so they are correct again (
+		if newatmosphere > self.sbenvironment.atmosphere then
+			self.sbenvironment.air.max = math.Round(100 * 5 * (self:GetVolume()/1000) * newatmosphere)
+			local tmp = self.sbenvironment.air.max - (self.sbenvironment.air.o2 + self.sbenvironment.air.co2 + self.sbenvironment.air.n + self.sbenvironment.air.h)
+			self.sbenvironment.air.other = tmp
+			self.sbenvironment.air.otherper = self:GetOtherGasesPercentage()
+		else
+			self.sbenvironment.air.o2 = math.Round(GetO2Percentage() * 5 * (self:GetVolume()/1000) * newatmosphere)
+			self.sbenvironment.air.co2 = math.Round(GetCO2Percentage() * 5 * (self:GetVolume()/1000) * newatmosphere)
+			self.sbenvironment.air.n = math.Round(GetNPercentage() * 5 * (self:GetVolume()/1000) * newatmosphere)
+			self.sbenvironment.air.h = math.Round(GetHPercentage() * 5 * (self:GetVolume()/1000) * newatmosphere)
+			self.sbenvironment.air.other = math.Round(GetOtherGasesPercentage() * 5 * (self:GetVolume()/1000) * newatmosphere)
+			self.sbenvironment.air.max = math.Round(100 * 5 * (self:GetVolume()/1000) * newatmosphere)
+		end
+		self.sbenvironment.atmosphere = newatmosphere
+	end
+
+	function ENT:ChangeGravity(newgravity)
+		if not newgravity or type(newgravity) != "number" then return "Invalid parameter" end
+		//Update the pressure since it's based on atmosphere and gravity
+		if self.sbenvironment.gravity != 0 then
+			self.sbenvironment.pressure = self.sbenvironment.pressure * (newgravity/self.sbenvironment.gravity)
+		else
+			self.sbenvironment.pressure = self.sbenvironment.pressure * newgravity
+		end
+		self.sbenvironment.gravity = newgravity
+	end
+
+	function ENT:GetEnvironmentName()
+		return self.sbenvironment.name
+	end
+
+	function ENT:SetEnvironmentName(value)
+		if not value then return end
+		self.sbenvironment.name = value
+	end
+
+	function ENT:GetGravity()
+		return self.sbenvironment.gravity or 0
+	end
+
+	function ENT:UpdatePressure(ent)
+		if not ent or GAMEMODE.Override_PressureDamage > 0 then return end
+		if ent:IsPlayer() and GAMEMODE.PlayerOverride > 0 then return end
+		if self.sbenvironment.pressure and self.sbenvironment.pressure > 1.5 then
+			ent:TakeDamage((self.sbenvironment.pressure - 1.5) * 10)
+		end
+	end
+
+	function ENT:Convert(air1, air2, value)
+		if not air1 or not air2 or not value then return end
+		if type(air1) != "number" or type(air2) != "number" or type(value) != "number" then return end 
+		
+		air1 = math.Round(air1)
+		air2 = math.Round(air2)
+		value = math.Round(value)
+		
+		if air1 < -1 or air1 > 3 then return 0 end
+		if air2 < -1 or air2 > 3 then return 0 end
+		
+		if air1 == air2 then return 0 end
+		if value < 1 then return 0 end
+		
+		if air1 == -1 then
+			if self.sbenvironment.air.other < value then
+				value = self.sbenvironment.air.other
+			end
+			
+			self.sbenvironment.air.other = self.sbenvironment.air.other - value
+			
+			if air2 == SB_AIR_CO2 then
+				self.sbenvironment.air.co2 = self.sbenvironment.air.co2 + value
+			elseif air2 == SB_AIR_N then
+				self.sbenvironment.air.n = self.sbenvironment.air.n + value
+			elseif air2 == SB_AIR_H then
+				self.sbenvironment.air.h = self.sbenvironment.air.h + value
+			elseif air2 == SB_AIR_O2 then
+				self.sbenvironment.air.o2 = self.sbenvironment.air.o2 + value
+			end
+		elseif air1 == SB_AIR_O2 then
+			if self.sbenvironment.air.o2 < value then
+				value = self.sbenvironment.air.o2
+			end
+			
+			self.sbenvironment.air.o2 = self.sbenvironment.air.o2 - value
+			
+			if air2 == SB_AIR_CO2 then
+				self.sbenvironment.air.co2 = self.sbenvironment.air.co2 + value
+			elseif air2 == SB_AIR_N then
+				self.sbenvironment.air.n = self.sbenvironment.air.n + value
+			elseif air2 == SB_AIR_H then
+				self.sbenvironment.air.h = self.sbenvironment.air.h + value
+			elseif air2 == -1 then
+				self.sbenvironment.air.other = self.sbenvironment.air.other + value
+			end
+		elseif air1 == SB_AIR_CO2 then
+			if self.sbenvironment.air.co2 < value then
+				value = self.sbenvironment.air.co2
+			end
+			
+			self.sbenvironment.air.co2 = self.sbenvironment.air.co2 - value
+			
+			if air2 == SB_AIR_O2 then
+				self.sbenvironment.air.o2 = self.sbenvironment.air.o2 + value
+			elseif air2 == SB_AIR_N then
+				self.sbenvironment.air.n = self.sbenvironment.air.n + value
+			elseif air2 == SB_AIR_H then
+				self.sbenvironment.air.h = self.sbenvironment.air.h + value
+			elseif air2 == -1 then
+				self.sbenvironment.air.other = self.sbenvironment.air.other + value
+			end
+		elseif air1 == SB_AIR_N then
+			if self.sbenvironment.air.n < value then
+				value = self.sbenvironment.air.n
+			end
+			
+			self.sbenvironment.air.n = self.sbenvironment.air.n - value
+			
+			if air2 == SB_AIR_O2 then
+				self.sbenvironment.air.o2 = self.sbenvironment.air.o2 + value
+			elseif air2 == SB_AIR_CO2 then
+				self.sbenvironment.air.co2 = self.sbenvironment.air.co2 + value
+			elseif air2 == SB_AIR_H then
+				self.sbenvironment.air.h = self.sbenvironment.air.h + value
+			elseif air2 == -1 then
+				self.sbenvironment.air.other = self.sbenvironment.air.other + value
+			end
+		else
+			if self.sbenvironment.air.h < value then
+				value = self.sbenvironment.air.h
+			end
+			
+			self.sbenvironment.air.h = self.sbenvironment.air.h - value
+			
+			if air2 == SB_AIR_O2 then
+				self.sbenvironment.air.o2 = self.sbenvironment.air.o2 + value
+			elseif air2 == SB_AIR_CO2 then
+				self.sbenvironment.air.co2 = self.sbenvironment.air.co2 + value
+			elseif air2 == SB_AIR_N then
+				self.sbenvironment.air.n = self.sbenvironment.air.n + value
+			elseif air2 == -1 then
+				self.sbenvironment.air.other = self.sbenvironment.air.other + value
+			end
+		end
+		
+		return value
+	end
+
+	function ENT:UpdateGravity(ent)
+		if not ent then return end
+		
+		local phys = ent:GetPhysicsObject()
+		if not phys:IsValid() then return end
+		
+		if self.sbenvironment.gravity == 0 then
+			local trace = {}
+			local pos = ent:GetPos()
+			trace.start = pos
+			trace.endpos = pos - Vector(0,0,512)
+			trace.filter = { ent }
+			local tr = util.TraceLine( trace )
+			
+			if (tr.Hit) and tr.Entity.grav_plate == 1 then
+				ent:SetGravity(1)
+				ent.gravity = 1
+				phys:EnableGravity( true )
+				phys:EnableDrag( true )
+				return
+			end
+		elseif ent.gravity and  ent.gravity == self.sbenvironment.gravity then 
+			return 
+		end
+		
+		if not self.sbenvironment.gravity or self.sbenvironment.gravity  == 0 then
+			phys:EnableGravity( false )
+			phys:EnableDrag( false )
+			ent:SetGravity(0.00001)
+			ent.gravity = 0
+		else
+			ent:SetGravity(self.sbenvironment.gravity)
+			ent.gravity = self.sbenvironment.gravity
+			phys:EnableGravity( true )
+			phys:EnableDrag( true )
+		end	
+	end
+
+	function ENT:GetAtmosphere()
+		return self.sbenvironment.atmosphere or 0
+	end
+
+	function ENT:GetPressure()
+		return self.sbenvironment.pressure or 0
+	end
+
+	function ENT:GetTemperature()
+		return self.sbenvironment.temperature or 0
+	end
+
+	function ENT:GetO2()
+		return self.sbenvironment.air.o2 or 0
+	end
+
+	function ENT:GetOtherGases()
+		return self.sbenvironment.air.other or 0
+	end
+
+	function ENT:GetCO2()
+		return self.sbenvironment.air.co2 or 0
+	end
+
+	function ENT:GetN()
+		return self.sbenvironment.air.n or 0
+	end
+
+	function ENT:GetH()
+		return self.sbenvironment.air.h or 0
+	end
+
+	function ENT:CreateEnvironment(gravity, atmosphere, pressure, temperature, o2, co2, n, h, name)
+		//Msg("CreateEnvironment: "..tostring(gravity).."\n")
+		//set Gravity if one is given
+		if gravity and type(gravity) == "number" then
+			if gravity < 0 then
+				gravity = 0
+			end
+			self.sbenvironment.gravity = gravity
+		end
+		//set atmosphere if given
+		if atmosphere and type(atmosphere) == "number" then
+			if atmosphere < 0 then
+				atmosphere = 0
+			elseif atmosphere > 1 then
+				atmosphere = 1
+			end
+			self.sbenvironment.atmosphere = atmosphere
+		end
+		//set pressure if given
+		if pressure and type(pressure) == "number" and pressure >= 0 then
+			self.sbenvironment.pressure = pressure
+		else 
+			self.sbenvironment.pressure = math.Round(self.sbenvironment.atmosphere * self.sbenvironment.gravity)
+		end
+		//set temperature if given
+		if temperature and type(temperature) == "number" then
+			self.sbenvironment.temperature = temperature
+		end
+		//set o2 if given
+		if o2 and type(o2) == "number" and o2 > 0 then
+			if o2 < 0 then o2 = 0 end
+			if o2 > 100 then o2 = 100 end
+			self.sbenvironment.air.o2per = o2
+			self.sbenvironment.air.o2 = math.Round(o2 * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+		else 
+			o2 = 0
+			self.sbenvironment.air.o2per = 0
+			self.sbenvironment.air.o2 = 0
+		end
+		//set co2 if given
+		if co2 and type(co2) == "number" and co2 > 0 then
+			if co2 < 0 then co2 = 0 end
+			if (100 - o2) < co2 then co2 = 100-o2 end
+			self.sbenvironment.air.co2per = co2
+			self.sbenvironment.air.co2 = math.Round(co2 * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+		else 
+			co2 = 0
+			self.sbenvironment.air.co2per = 0
+			self.sbenvironment.air.co2 = 0
+		end
+		//set n if given
+		if n and type(n) == "number" and n > 0 then
+			if n < 0 then n = 0 end
+			if ((100 - o2)-co2) < n then n = (100-o2)-co2 end
+			self.sbenvironment.air.nper = n
+			self.sbenvironment.air.n = math.Round(n * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+		else 
+			n = 0
+			self.sbenvironment.air.n = 0
+			self.sbenvironment.air.n = 0
+		end
+		//set h if given
+		if h and type(h) == "number" and h > 0 then
+			if h < 0 then h = 0 end
+			if (((100 - o2)-co2)-n) < h then h = ((100-o2)-co2)-n end
+			self.sbenvironment.air.hper = h
+			self.sbenvironment.air.h = math.Round(h * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+		else 
+			h = 0
+			self.sbenvironment.air.h = 0
+			self.sbenvironment.air.h = 0
+		end
+		if o2 + co2 + n + h < 100 then
+			local tmp = 100 - (o2 + co2 + n + h)
+			self.sbenvironment.air.other = math.Round(tmp * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+			self.sbenvironment.air.otherper = tmp
+		elseif o2 + co2 + n + h > 100 then
+			local tmp = (o2 + co2 + n + h) - 100
+			if co2 > tmp then
+				self.sbenvironment.air.co2 = math.Round((co2 - tmp) * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+				self.sbenvironment.air.co2per = co2 + tmp
+			elseif n > tmp then
+				self.sbenvironment.air.n = math.Round((n - tmp) * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+				self.sbenvironment.air.nper = n + tmp
+			elseif h > tmp then
+				self.sbenvironment.air.h = math.Round((h - tmp) * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+				self.sbenvironment.air.hper = h + tmp
+			elseif o2 > tmp then
+				self.sbenvironment.air.o2 = math.Round((o2 - tmp) * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+				self.sbenvironment.air.o2per = o2 - tmp
+			end
+		end
+		if name then
+			self.sbenvironment.name = name
+		end
+		
+		self.sbenvironment.air.max = math.Round(100 * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+		
+		return self:PrintVars()
+	end
+
+	function ENT:UpdateEnvironment(gravity, atmosphere, pressure, temperature, o2, co2, n, h)
+		self:ChangeGravity(gravity)
+		if atmosphere then self:ChangeAtmosphere(atmosphere) end
+		
+		if pressure and type(pressure) == "number" then
+			if pressure < 0 then
+				pressure = 0
+			end
+			self.sbenvironment.pressure = pressure
+		end
+		//set temperature if given
+		if temperature and type(temperature) == "number" then
+			self.sbenvironment.temperature = temperature
+		end
+		self.sbenvironment.air.max = math.Round(100 * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+		//set o2 if given
+		if o2 and type(o2) == "number" then
+			if o2 < 0 then o2 = 0 end
+			if o2 > 100 then o2 = 100 end
+			self.sbenvironment.air.o2 = math.Round(o2 * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+			self.sbenvironment.air.o2per = o2
+		else 
+			o2 = self:GetO2Percentage()
+		end
+		//set co2 if given
+		if co2 and type(co2) == "number" then
+			if co2 < 0 then co2 = 0 end
+			if (100 - o2) < co2 then co2 = 100-o2 end
+			self.sbenvironment.air.co2 = math.Round(co2 * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+			self.sbenvironment.air.co2per = co2
+		else 
+			co2 = self:GetCO2Percentage()
+		end
+		//set n if given
+		if n and type(n) == "number" then
+			if n < 0 then n = 0 end
+			if ((100 - o2)-co2) < n then n = (100-o2)-co2 end
+			self.sbenvironment.air.n = math.Round(n * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+			self.sbenvironment.air.nper = n
+		else 
+			n = self:GetNPercentage()
+		end
+		if h and type(h) == "number" then
+			if h < 0 then h = 0 end
+			if (((100 - o2)-co2)-n) < h then h = (((100-o2)-co2)-n) end
+			self.sbenvironment.air.h = math.Round(h * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+			self.sbenvironment.air.hper = h
+		else 
+			h = self:GetHPercentage()
+		end
+		if o2 + co2 + n + h < 100 then
+			local tmp = 100 - (o2 + co2 + n + h)
+			self.sbenvironment.air.other = math.Round(tmp * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+			self.sbenvironment.air.otherper = tmp
+		elseif o2 + co2 + n + h > 100 then
+			local tmp = (o2 + co2 + n + h) - 100
+			if co2 >= tmp then
+				self.sbenvironment.air.co2 = math.Round((co2 - tmp) * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+				self.sbenvironment.air.co2per = co2 + tmp
+			elseif n >= tmp then
+				self.sbenvironment.air.n = math.Round((n - tmp) * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+				self.sbenvironment.air.nper = n + tmp
+			elseif h >= tmp then
+				self.sbenvironment.air.h = math.Round((h - tmp) * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+				self.sbenvironment.air.hper = h + tmp
+			elseif o2 >= tmp then
+				self.sbenvironment.air.o2 = math.Round((o2 - tmp) * 5 * (self:GetVolume()/1000) * self.sbenvironment.atmosphere)
+				self.sbenvironment.air.o2per = o2 - tmp
+			end
+		end
+		
+		self:PrintVars()
+	end
+
+	function ENT:GetVolume()
+		return 9001 -- You saw this coming.
+	end
+
+	function ENT:IsEnvironment()
+		return true
+	end
+
+	function ENT:IsPlanet()
+		return false
+	end
+
+	function ENT:IsStar()
+		return false
+	end
+
+	function ENT:IsSpace()
+		return false
+	end
+	 
+	function ENT:OnEnvironment(ent)
+		return (ent.BrushEnvStack and (ent.BrushEnvStack[#ent.BrushEnvStack] == self.ID))
+	end
+
+	function ENT:Remove()
+		GAMEMODE:RemoveEnvironment(self)
+	end
+end

--- a/lua/entities/sb_environment/init.lua
+++ b/lua/entities/sb_environment/init.lua
@@ -1,0 +1,361 @@
+include("Extensions/sv_brush_env_base_funcs.lua")
+
+ENT.Base		= "base_brush"
+ENT.Type		= "brush"
+ENT.Debugging	= true
+ENT.Enabled		= true
+ENT.GetEnvClass	= "SB ENVIRONMENT"
+
+SB_Environments_Brush_List = SB_Environments_Brush_List or {}
+local Init_Debugging_Override = true
+
+function ENT:Initialize()
+	if not self.Initialized then
+		self:InitEnvBrush()
+	end
+	
+	if GAMEMODE and GAMEMODE.AddEnvironment then
+		GAMEMODE:AddEnvironment(self)
+	elseif not GAMEMODE then
+		for i = 1, 9001 do -- For good measure. Hell, if it does happen then they deserve it!
+			Error("OMGAZ!!1 Yo3 No0t runizngz aA Gam3am0dez!\n")
+		end
+	end
+
+	self.SpacedVector = Vector(self.sbenvironment.DecompressionSettings.X or 0, 
+							   self.sbenvironment.DecompressionSettings.Y or 0, 
+							   self.sbenvironment.DecompressionSettings.Z or 0)
+
+	if Init_Debugging_Override or self.Debugging then
+		Msg("Initialized a new brush env: ", self, "\n")
+		Msg("ID is: ", self.ID, "\n")
+		Msg("Dumping stats:\n")
+		Msg("\n\n------------ START DUMP ------------\n\n")
+		PrintTable(self)
+		Msg("\n\n------------- END DUMP -------------\n\n")
+	end
+end
+
+function ENT:StartTouch(entity)
+	if not self.Enabled then 
+		if self.Debugging then Msg("Entity ", entity, " tried to enter but ", self, " wasn't on.\n") end
+		
+		return
+	elseif self.Debugging then 
+		Msg("Entity ", entity, " has started touching ", self, " in unusual places....\n")
+	end
+	
+	entity.IsInEnvBrush = true
+	entity.environment = self
+	self:UpdateGravity(entity)
+	self.Entities[entity] = entity
+end
+
+function ENT:EndTouch(entity)
+	if self.Debugging then
+		Msg("Entity ", entity, " has stopped touching ", self, " in unusual places....\n")
+	end
+	
+	if SB_Environments_Brush_List[self.ParentID] then
+		entity.environment = SB_Environments_Brush_List[self.ParentID]
+		if self.Debugging then
+			Msg("...and has started touching our parent, ", SB_Environments_Brush_List[self.ParentID], " in unusual places....\n")
+		end
+	else //SPACE TEH BASTERD
+		entity.IsInBrushEnv = false
+		entity.environment = nil
+		
+		if self.Debugging then Msg("...and has decided to get spaced.\n") end
+	end
+	
+	self.Entities[entity] = nil
+end
+
+function ENT:Space()
+	for k, v in pairs(self.Entities) do
+		-- I'm assuming that even if they have LS devices that unsuited people have a tendency to DIE when explosive decompression occures
+		-- Of course this is dependent on the amount of gases inside
+		self.sbenvironment.air.max = self.sbenvironment.air.max or 100 --math.Round(100 * data * 5) * self.sbenvironment.pressure
+		if v and v.IsNPC and v:IsNPC() then
+			local dmg = self.sbenvironment.pressure *  math.random(1,9001)
+			v:TakeDamage(dmg, self, self)
+		elseif v and v.IsPlayer and v:IsPlayer() and (not v:InVehicle()) then
+			local dmg = self.sbenvironment.pressure * math.random(1,9001)
+			v:TakeDamage(dmg, self, self)
+		end
+		
+		local phys = v:GetPhysicsObject()
+		
+		if phys and phys:IsValid() then
+			phys:ApplyForceCenter(self.SpacedVector)
+		end
+		--and for good measure
+		if v.SetVelocityInstantaneous then
+			v:SetVelocityInstantaneous(self.SpacedVector)
+		elseif v.SetVelocity then
+			v:SetVelocity(self.SpacedVector)
+		end
+		
+		v.IsInBrushEnv = false
+	end
+	
+	self.Enabled = false
+end
+
+function ENT:AcceptInput(name, activator, caller, data)
+	if not self.Initialized then
+		self:InitEnvBrush()
+	end
+	
+	if name == "SpaceEnv" then
+		self:Space()
+		
+		return true
+	elseif name == "RestoreEnv" then
+		self.Enabled = true
+		
+		return true
+	elseif name == "SetPressure" then
+		if not (data and (type(data) == "number")) then return Error("Invalid parameter for new pressure in env brush ID" .. self.ID .. "\n") end
+		
+		if data < 0 then
+			data = 0
+		elseif data > 1 then
+			data = 1
+		end
+		
+		if self.sbenvironment.atmosphere ~= 0 then
+			self.sbenvironment.pressure = self.sbenvironment.pressure * (data / self.sbenvironment.atmosphere)
+		else
+			self.sbenvironment.pressure = self.sbenvironment.pressure * data
+		end
+		
+		if data > self.sbenvironment.atmosphere then
+			local tmp = self.sbenvironment.air.max - (self.sbenvironment.air.o2 + self.sbenvironment.air.co2 + self.sbenvironment.air.n + self.sbenvironment.air.h)
+			
+			self.sbenvironment.air.max = math.Round(100 * data * 5)
+
+			self.sbenvironment.air.empty = tmp
+			self.sbenvironment.air.emptyper = self:GetOtherGasPercentage()
+		else
+			self.sbenvironment.air.o2		= math.Round(self:GetO2Percentage() * data * 5)
+			self.sbenvironment.air.co2		= math.Round(self:GetCO2Percentage() * data * 5)
+			self.sbenvironment.air.n		= math.Round(self:GetNPercentage() * data * 5)
+			self.sbenvironment.air.h		= math.Round(self:GetHPercentage() * data * 5)
+			self.sbenvironment.air.empty	= math.Round(self:GetOtherGasPercentage() * data * 5)
+			self.sbenvironment.air.max		= math.Round(100 * data * 5)
+		end
+		
+		self.sbenvironment.atmosphere = data
+		
+		return true
+	elseif name == "Temp" then
+		SB_BrushEnvironments.SetSunTemp(self.ID, tonumber(data))
+		
+		
+		return true
+	elseif name == "SetGravity" then
+		if (not data) and (type(data) == "number") then return Error("Invalid parameter for new gravity in env brush ID" .. self.ID .. "\n") end
+		
+		if self.sbenvironment.gravity ~= 0 then
+			self.sbenvironment.pressure = self.sbenvironment.pressure * (data/self.sbenvironment.gravity)
+		else
+			self.sbenvironment.pressure = self.sbenvironment.pressure * newgravityz
+		end
+		
+		self.sbenvironment.gravity = data
+		
+		return true
+	elseif name == "SetUnstable" then
+		self.sbenvironment.unstable = (tonumber(data) == 1)
+		
+		return true
+	end
+	
+	return false
+end
+
+function ENT:OnRemove()
+
+end
+
+function ENT:PassesTriggerFilters(entity)
+	if not self.Initialized then
+		self:InitEnvBrush()
+	end
+	
+	do
+		return true
+	end
+	
+	if self.Debugging then
+		Msg("Filtering ", entity, "...\n")
+	end
+	
+	if (not entity.ProcessesEnvChanges) or (not GM.affected[entity.SB_ClassName or entity:GetClass()]) then
+		if self.Debugging then
+			Msg("Attempting to pass entity: ", entity, "; This was denied.\n")
+			Msg("The marker for it was set to ", entity.DontProcessesEnvChanges, ".\n")
+		end
+		
+		entity.ProcessesEnvChanges = false
+		return false
+	end
+	
+	entity.SB_ClassName = entity:GetClass()
+	entity.ProcessesEnvChanges = true
+	
+	if self.Debugging then
+		Msg("Entity ", entity, " was cleared.\n")
+	end
+	
+	return true
+end
+
+function ENT:Think()
+end
+
+function ENT:Touch(entity)
+end
+
+function ENT:InitEnvBrush()
+	SB_Brush_Environment_Load_Base_Func_Extensions1(self) -- HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ! HAKZ!
+	
+	self.sbenvironment							= {}
+	self.sbenvironment.air						= {}
+	self.sbenvironment.name						= "Aperture Science Extremely Inelegant Singly Developed Incomprehensible Undocumented Atmospheric Phenomenon Simulation Chamber(r) 2008 - 9001 by Cynical Fruits Productions, a division of Aperture Science Shower Curtains Manufactures Inc."
+	self.sbenvironment.BloomSettings			= {}
+	self.sbenvironment.ColourModSettings		= {}
+	self.sbenvironment.DecompressionSettings	= {}
+	
+	self.ParentID		= self.ParentID or -1
+	self.Enabled		= true
+	
+	self.Entities		= self.Entities or {}
+	self.SpacedVector	= self.SpacedVector or Vector(0, 0, 0)
+	
+	self.Initialized = true or false -- for the lulz
+end
+
+function ENT:SetEnvironmentID(duh)
+	self.GazeboOfDeath = duh or 1337
+end
+
+function ENT:GetEnvironmentID()
+	return self.GazeboOfDeath or 1337
+end
+
+
+function ENT:KeyValue(k, v)
+	if not self.Initialized then
+		self:InitEnvBrush()
+	end
+	
+	if k == "BrushName" then
+		self.EnvName = v
+		self.sbenvironment.name = self.EnvName
+		return
+	end
+	
+	v = tonumber(v) or 0
+	
+	-------------------------------------------------------------------------------
+	---------			Std. Env Stuff				---------
+	-------------------------------------------------------------------------------
+	
+	
+	if k == "BrushEnvID" then
+		self.ID = v
+		
+		if SB_Environments_Brush_List[self.ID] then ErrorNoHalt("NON FATALE ERROR: THERE ARE MULTIPLE USES OF " .. self.ID .. " AS A ENVIRONMENT BRUSH! OVERRIDING!\n") end
+		
+		SB_Environments_Brush_List[self.ID] = self
+	elseif k == "ParentBrushEnvID" then
+		self.ParentID = v
+	elseif k == "Gravity" then
+		self.sbenvironment.gravity = v
+	elseif k == "Atmosphere" then
+		self.sbenvironment.atmosphere = v
+	elseif k == "Pressure" then
+		self.sbenvironment.pressure = v
+	elseif k == "Temp" then
+		self.sbenvironment.temperature = v
+	elseif k == "Oxygen" then
+		self.sbenvironment.air.o2 = v
+	elseif k == "Carbon_Dioxide" then
+		self.sbenvironment.air.co2 = v
+	elseif k == "Nitrogen" then
+		self.sbenvironment.air.n = v
+	elseif k == "Hydrogen" then
+		self.sbenvironment.air.h = v
+	elseif k == "AirThickness" then
+		self.sbenvironment.air.AirThickness = v
+	elseif k == "Habitable" then
+		self.sbenvironment.habitable = v
+	elseif k == "Stable" then
+		self.sbenvironment.unstable = (v ~= 1)
+		
+	-------------------------------------------------------------------------------
+	---------			Bloom  Stuff					---------
+	-------------------------------------------------------------------------------
+	
+	elseif k == "HasBloom" then
+		self.sbenvironment.BloomSettings.Has = (v == 1)
+	elseif k == "Bloom_R" then
+		self.sbenvironment.BloomSettings.AddRed = v
+	elseif k == "Bloom_G" then
+		self.sbenvironment.BloomSettings.AddGreen = v
+	elseif k == "Bloom_B" then
+		self.sbenvironment.BloomSettings.AddBlue = v
+	elseif k == "Bloom_X" then
+		self.sbenvironment.BloomSettings.Passes_X = v
+	elseif k == "Bloom_Y" then
+		self.sbenvironment.BloomSettings.Passes_Y = v
+	elseif k == "Bloom_Passes" then
+		self.sbenvironment.BloomSettings.Passes = v
+	elseif k == "Bloom_Darken" then
+		self.sbenvironment.BloomSettings.Darken = v
+	elseif k == "Bloom_Multiplier" then
+		self.sbenvironment.BloomSettings.Multi = v
+		
+	-------------------------------------------------------------------------------
+	---------			Colour Modification Stuff		---------
+	-------------------------------------------------------------------------------
+		
+	elseif k == "Colour_Mod" then
+		self.sbenvironment.ColourModSettings.Has = (v == 1)
+	elseif k == "Colour_Mod_R" then
+		self.sbenvironment.ColourModSettings.AddRed = v
+	elseif k == "Colour_Mod_G" then
+		self.sbenvironment.ColourModSettings.AddGreen = v
+	elseif k == "Colour_Mod_B" then
+		self.sbenvironment.ColourModSettings.AddBlue = v
+	elseif k == "Colour_Mod_M_R" then
+		self.sbenvironment.ColourModSettings.MultiRed = v
+	elseif k == "Colour_Mod_M_G" then
+		self.sbenvironment.ColourModSettings.MultiGreen = v
+	elseif k == "Colour_Mod_M_B" then
+		self.sbenvironment.ColourModSettings.MultiBlue = v
+	elseif k == "Colour_Mod_Brightness" then
+		self.sbenvironment.ColourModSettings.Brightness = v
+	elseif k == "Colour_Mod_Contrast" then
+		self.sbenvironment.ColourModSettings.Contrast = v
+	elseif k == "Colour_Mod_Range" then
+		self.sbenvironment.ColourModSettings.Range = v
+		
+	-------------------------------------------------------------------------------
+	---------			Decompression Stuff			---------
+	-------------------------------------------------------------------------------
+	
+	elseif k == "Decompression_Explosion_X" then
+		self.sbenvironment.DecompressionSettings.X = v
+	elseif k == "Decompression_Explosion_Y" then
+		self.sbenvironment.DecompressionSettings.Y = v
+	elseif k == "Decompression_Explosion_Z" then		
+		self.sbenvironment.DecompressionSettings.Z = v
+	else
+		ErrorNoHalt("Unhandled KV pair!\n")
+		ErrorNoHalt("Key: " .. tostring(k) .. " | Value: " .. tostring(v) .. "\n")
+	end
+end
+

--- a/lua/entities/sb_environment/init.lua
+++ b/lua/entities/sb_environment/init.lua
@@ -19,7 +19,7 @@ function ENT:Initialize()
 		SB:AddEnvironment(self)
 	elseif not SB then
 		for i = 1, 9001 do -- For good measure. Hell, if it does happen then they deserve it!
-			Error("OMGAZ!!1 Yo3 No0t runizngz aA Gam3am0dez!\n")
+			Error("You're not running spacebuild. :(\n")
 		end
 	end
 

--- a/lua/entities/sb_environment/init.lua
+++ b/lua/entities/sb_environment/init.lua
@@ -8,6 +8,7 @@ ENT.GetEnvClass	= "SB ENVIRONMENT"
 
 SB_Environments_Brush_List = SB_Environments_Brush_List or {}
 local Init_Debugging_Override = true
+local SB = CAF.GetAddon("Spacebuild")
 
 function ENT:Initialize()
 	if not self.Initialized then
@@ -21,12 +22,15 @@ function ENT:Initialize()
 		for i = 1, 9001 do -- For good measure. Hell, if it does happen then they deserve it!
 			Error("You're not running spacebuild. :(\n")
 		end
+	else
+		Error("AddEnvironment function does not exist :(")
 	end
 
 	self.SpacedVector = Vector(self.sbenvironment.DecompressionSettings.X or 0, 
 							   self.sbenvironment.DecompressionSettings.Y or 0, 
 							   self.sbenvironment.DecompressionSettings.Z or 0)
 
+	/*This is broke
 	if Init_Debugging_Override or self.Debugging then
 		Msg("Initialized a new brush env: ", self, "\n")
 		Msg("ID is: ", self.ID, "\n")
@@ -34,7 +38,7 @@ function ENT:Initialize()
 		Msg("\n\n------------ START DUMP ------------\n\n")
 		PrintTable(self)
 		Msg("\n\n------------- END DUMP -------------\n\n")
-	end
+	end*/
 end
 
 function ENT:StartTouch(entity)

--- a/lua/entities/sb_environment/init.lua
+++ b/lua/entities/sb_environment/init.lua
@@ -14,9 +14,10 @@ function ENT:Initialize()
 		self:InitEnvBrush()
 	end
 	
-	if GAMEMODE and GAMEMODE.AddEnvironment then
-		GAMEMODE:AddEnvironment(self)
-	elseif not GAMEMODE then
+	//Spacebuild is no longer a gamemode
+	if SB and SB.AddEnvironment then
+		SB:AddEnvironment(self)
+	elseif not SB then
 		for i = 1, 9001 do -- For good measure. Hell, if it does happen then they deserve it!
 			Error("OMGAZ!!1 Yo3 No0t runizngz aA Gam3am0dez!\n")
 		end

--- a/lua/entities/sb_environment/init.lua
+++ b/lua/entities/sb_environment/init.lua
@@ -1,4 +1,4 @@
-include("Extensions/sv_brush_env_base_funcs.lua")
+include("extensions/sv_brush_env_base_funcs.lua")
 
 ENT.Base		= "base_brush"
 ENT.Type		= "brush"


### PR DESCRIPTION
Adds the brush entities that are defined in the FGD. Technically you can never be inside the brush entities environment, so they are useless but it should stop any errors on maps that use them. Kudos to whoever originally wrote this entity, I've made some changes to make it run in SB3 but besides that is all the same.
